### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ jobs:
         elixir: ["1.13"]
         otp: ["24", "23", "22"]
         os: ["ubuntu-20.04"]
-        include:
-          - { elixir: "1.12", otp: "24", os: "ubuntu-20.04" }
-          - { elixir: "1.11", otp: "24", os: "ubuntu-20.04" }
-          - { elixir: "1.10", otp: "23", os: "ubuntu-20.04" }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,7 @@ jobs:
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir }}
+    - run: mix deps.get
+    - run: mix deps.compile
     - run: mix compile --warnings-as-errors
     - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ jobs:
           - { elixir: "1.12", otp: "24", os: "ubuntu-20.04" }
           - { elixir: "1.11", otp: "24", os: "ubuntu-20.04" }
           - { elixir: "1.10", otp: "23", os: "ubuntu-20.04" }
-          - { elixir: "1.9", otp: "22", os: "ubuntu-20.04" }
-          - { elixir: "1.8", otp: "22", os: "ubuntu-20.04" }
-          - { elixir: "1.7", otp: "22", os: "ubuntu-20.04" }
-          - { elixir: "1.6", otp: "21", os: "ubuntu-20.04" }
-          - { elixir: "1.5", otp: "20", os: "ubuntu-20.04" }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExSamples.Mixfile do
     [
       app: :exsamples,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.10",
       description: description(),
       package: package(),
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExSamples.Mixfile do
     [
       app: :exsamples,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.13.2",
       description: description(),
       package: package(),
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExSamples.Mixfile do
     [
       app: :exsamples,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.13",
       description: description(),
       package: package(),
       deps: deps()


### PR DESCRIPTION
- get and compile dependencies on CI
- remove support for elixir 1.5 to 1.9, because sourceror requires Elixir "~> 1.10" 
- remove support for elixir 1.10 to 1.12, because Mix.Tasks.Format was not a behaviour

If support for older versions is required we need to "hide" the formatter on those versions.