### PR TITLE
Fix Elixir version requirement to allow Elixir 1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,16 @@ jobs:
       matrix:
         # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
         # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
-        elixir: ["1.13"]
-        otp: ["24", "23", "22"]
+        elixir: ["1.13.2", "1.14"]
+        otp: ["25", "24", "23", "22"]
         os: ["ubuntu-20.04"]
+        exclude:
+          - otp: 22
+            elixir: 1.14
+          # Erlang 25 is only compatible with Elixir >= 1.13.4
+          - otp: 25
+            elixir: 1.13.2
+
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExSamples.Mixfile do
     [
       app: :exsamples,
       version: "0.1.0",
-      elixir: "~> 1.13.2",
+      elixir: "~> 1.13 and >= 1.13.2",
       description: description(),
       package: package(),
       deps: deps()


### PR DESCRIPTION
With Elixir 1.14 my project compiles with the following warning:
```console
==> exsamples
warning: the dependency :exsamples requires Elixir "~> 1.13.2" but you are running on v1.14.0
```